### PR TITLE
Optimize metrics endpoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,5 @@
 FROM elixir
 
-RUN apt-get update && apt-get install -y socat
-
 WORKDIR /kastlex
 
 # Cache dependencies

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,11 +4,14 @@ services:
   kastlex:
     build: .
     hostname: kastlex
+    environment:
+      KASTLEX_KAFKA_CLUSTER: kafka:9092
+      KASTLEX_ZOOKEEPER_CLUSTER: kafka:2181
     ports:
       - 8092
     depends_on:
       - kafka
-    command: bash -c "socat TCP-LISTEN:9092,fork TCP:kafka:9092 & socat TCP-LISTEN:2181,fork TCP:kafka:2181 & mix phoenix.server"
+    command: mix phoenix.server
 
   kafka:
     image: spotify/kafka

--- a/lib/kastlex/cg_cache.ex
+++ b/lib/kastlex/cg_cache.ex
@@ -38,6 +38,18 @@ defmodule Kastlex.CgCache do
     end
   end
 
+  ## Returns all consumer groups with their committed offsets
+  def get_consumer_groups_offsets() do
+    :dets.select(@offsets, [{{:"$1", :"$2"}, [], [{{:"$1", :"$2"}}]}])
+    |> Enum.flat_map(fn({group_id, topics}) ->
+      topics
+      |> Enum.map(fn({{topic, partition}, details}) ->
+        offset =  Keyword.fetch!(details, :offset)
+        %{group_id: group_id, topic: topic, partition: partition, offset: offset}
+      end)
+    end)
+  end
+
   def committed_offset(key, value) do
     group_id = ets_key = key[:group_id]
     map_key = {key[:topic], key[:partition]}

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Kastlex.Mixfile do
   def project do
     [app: :kastlex,
      description: "Apache Kafka REST Proxy",
-     version: "1.5.2",
+     version: "1.5.3",
      elixir: "~> 1.5",
      elixirc_paths: elixirc_paths(Mix.env),
      compilers: [:phoenix, :gettext] ++ Mix.compilers,

--- a/web/controllers/metrics_controller.ex
+++ b/web/controllers/metrics_controller.ex
@@ -25,13 +25,9 @@ defmodule Kastlex.MetricsController do
   end
 
   defp cg_offsets do
-    Kastlex.CgCache.get_groups()
-    |> Enum.flat_map(fn(group_id) ->
-      Kastlex.CgCache.get_group(group_id)
-      |> Map.get(:offsets)
-      |> Enum.map(fn(offset) ->
-        cg_offset_to_prometheus(group_id, offset)
-      end)
+    Kastlex.CgCache.get_consumer_groups_offsets()
+    |> Enum.map(fn(cg_offset) ->
+      cg_offset_to_prometheus(cg_offset)
     end)
   end
 
@@ -42,8 +38,8 @@ defmodule Kastlex.MetricsController do
     end)
   end
 
-  defp cg_offset_to_prometheus(group_id, cg_offset) do
-    %{topic: topic, partition: partition, offset: offset} = cg_offset
+  defp cg_offset_to_prometheus(cg_offset) do
+    %{group_id: group_id, topic: topic, partition: partition, offset: offset} = cg_offset
 
     ~s(kafka_consumer_group_offset{consumer_group="#{group_id}", topic="#{topic}", partition="#{partition}"} #{offset})
   end

--- a/web/controllers/metrics_controller.ex
+++ b/web/controllers/metrics_controller.ex
@@ -8,8 +8,7 @@ defmodule Kastlex.MetricsController do
   use Kastlex.Web, :controller
 
   def fetch(conn, _params) do
-    # Newline at the end is needed to satisfy Prometheus parser
-    metrics = Enum.join(offsets(), "\n") <> "\n"
+    metrics = IO.chardata_to_string(offsets())
 
     conn
     |> put_resp_content_type("text/plain; version=0.0.4")
@@ -17,11 +16,12 @@ defmodule Kastlex.MetricsController do
   end
 
   defp offsets do
-    off = Enum.concat(cg_offsets(), topic_offsets())
-    Enum.concat([
-      "# TYPE kafka_consumer_group_offset gauge",
-      "# TYPE kafka_topic_offset gauge"
-    ], off)
+    [
+      "# TYPE kafka_consumer_group_offset gauge\n",
+      "# TYPE kafka_topic_offset gauge\n",
+      cg_offsets(),
+      topic_offsets()
+    ]
   end
 
   defp cg_offsets do
@@ -41,12 +41,12 @@ defmodule Kastlex.MetricsController do
   defp cg_offset_to_prometheus(cg_offset) do
     %{group_id: group_id, topic: topic, partition: partition, offset: offset} = cg_offset
 
-    ~s(kafka_consumer_group_offset{consumer_group="#{group_id}", topic="#{topic}", partition="#{partition}"} #{offset})
+    ["kafka_consumer_group_offset{consumer_group=\"", group_id, "\", topic=\"", topic, "\", partition=\"", to_string(partition), "\"} ", to_string(offset), "\n"]
   end
 
   defp topic_offset_to_prometheus(topic_offset) do
     %{topic: topic, partition: partition, offset: offset} = topic_offset
 
-    ~s(kafka_topic_offset{topic="#{topic}", partition="#{partition}"} #{offset})
+    ["kafka_topic_offset{topic=\"", topic, "\", partition=\"", to_string(partition), "\"} ", to_string(offset), "\n"]
   end
 end


### PR DESCRIPTION
Extracted function to get the list of consumer groups with their respective offsets directly.

Compared with previous implementation on local Kafka with about 400 topics and consumer groups. Endpoint response time went down from `43ms` to `2ms`. I don't have bigger Kafka readily accessible, so any ideas how to quickly create lots of consumer groups, topics, and partitions are welcomed.